### PR TITLE
Tune .vscodeignore to include lib files (fixes #1)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,10 @@
 .vscode/
 .vscode-test/
+build/
 
 **/*.map
 **/*.ts
+!**/lib*.d.ts
 **/tsconfig.json
 **/tslint.json
 azure-pipelines.yml


### PR DESCRIPTION
This PR fixes #1 - problem with missing built-in `lib.*.d.ts` files.
Other `.d.ts` files for TS internals aren't included.

Also makes small additional clean-up - removes `build` folder from bundled extension.