### PR TITLE
Remove unnecessary extensionKind key

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
   "engines": {
     "vscode": "^1.36.0"
   },
-  "extensionKind": [
-    "workspace"
-  ],
   "workspaceTrust": {
     "request": "never"
   },


### PR DESCRIPTION
This pull request attempts to fix the following warning:
```[/Users/dave/.vscode/extensions/ms-vscode.vscode-typescript-next-4.8.20220618]: property `extensionKind` can be defined only if property `main` is also defined.```

The fix is based on https://github.com/microsoft/vscode/issues/143953.