### PR TITLE
Fix grammars for bracket-pair-colorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,12 @@
         "language": "javascriptreact",
         "scopeName": "source.js.jsx",
         "path": "./syntaxes/JavaScriptReact.tmLanguage.json",
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "punctuation.definition.tag"
+        ],
         "embeddedLanguages": {
           "meta.tag.js": "jsx-tags",
           "meta.tag.without-attributes.js": "jsx-tags",

--- a/package.json
+++ b/package.json
@@ -48,12 +48,6 @@
         "language": "javascriptreact",
         "scopeName": "source.js.jsx",
         "path": "./syntaxes/JavaScriptReact.tmLanguage.json",
-        "unbalancedBracketScopes": [
-          "keyword.operator.relational",
-          "storage.type.function.arrow",
-          "keyword.operator.bitwise.shift",
-          "punctuation.definition.tag"
-        ],
         "embeddedLanguages": {
           "meta.tag.js": "jsx-tags",
           "meta.tag.without-attributes.js": "jsx-tags",
@@ -88,6 +82,12 @@
         "language": "typescript",
         "scopeName": "source.ts",
         "path": "./syntaxes/TypeScript.tmLanguage.json",
+        "unbalancedBracketScopes": [
+          "keyword.operator.relational",
+          "storage.type.function.arrow",
+          "keyword.operator.bitwise.shift",
+          "punctuation.definition.tag"
+        ],
         "tokenTypes": {
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",


### PR DESCRIPTION
The issue was fixed in TypeScriptReact, but the problem still occurred in PlainTypeScript.
Also, VSCode did not add fields for JavaScriptReact, so I removed them from this package.

I have rewritten `~/.vscode-insiders/extensions/ms-vscode.vscode-typescript-next-4.8.20220718/package.json` to confirm that it has been corrected.

ref: https://github.com/microsoft/vscode/blob/a74adedba8fb56d14f01f7950340dab33cfeae57/extensions/typescript-basics/package.json#L63-L109
https://github.com/microsoft/vscode/blob/a74adedba8fb56d14f01f7950340dab33cfeae57/extensions/javascript/package.json#L59-L98