### PR TITLE
Corrected formatting of text regarding selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ To make sure you are using `typescript@next`:
 
 1. Open a JavaScript or TypeScript file in VS Code.
 1. In the VS Code command palette, run the `TypeScript: Select TypeScript version` command.
-1. Make sure you have `Use VS Code's version selected`
+1. Make sure you have `Use VS Code's version` selected
 
 Note that this extension also includes the [latest JavaScript and TypeScript grammar](https://github.com/microsoft/TypeScript-TmLanguage).


### PR DESCRIPTION
Before, the text `Use VS Code's version selected` was emphasized. The menu text is only `Use VS Code's version` and the "selected" should not be part of the emphasized text.