### PR TITLE
Make VERSION_SUFFIX parameter optional

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ parameters:
   - name: VERSION_SUFFIX
     displayName: Suffix appended to package version.
     type: string
-    default: ""
+    default: " "
 
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates

--- a/build/updatePackageVersion.js
+++ b/build/updatePackageVersion.js
@@ -6,7 +6,7 @@ const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json
 const jsonLock = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package-lock.json')).toString());
 
 // Set version to TS Version
-const versionSuffix = process.argv[2] || '';
+const versionSuffix = (process.argv[2] || '').trim();
 const version = jsonLock['dependencies']['typescript']['version'].replace(/0?\-\w*\./g, '') + versionSuffix;
 if (version === json['version']) {
     console.log(`Already at latest version ${version}`);


### PR DESCRIPTION
Apparently `default: ""` is means that the parameter is still required 