### PR TITLE
Add workaround for high version

### DIFF
--- a/build/updatePackageVersion.js
+++ b/build/updatePackageVersion.js
@@ -6,8 +6,16 @@ const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json
 const jsonLock = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package-lock.json')).toString());
 
 // Set version to TS Version
-const versionSuffix = (process.argv[2] || '').trim();
-const version = jsonLock['dependencies']['typescript']['version'].replace(/0?\-\w*\./g, '') + versionSuffix;
+let versionSuffix = (process.argv[2] || '').trim();
+
+const baseVersion = jsonLock['dependencies']['typescript']['version'].replace(/0?\-\w*\./g, '');
+
+// Hack to work around bad published version that has a trailing 0
+if (baseVersion.startsWith('5.0.')) {
+    versionSuffix = '0' + versionSuffix;
+}
+
+const version = baseVersion + versionSuffix;
 if (version === json['version']) {
     console.log(`Already at latest version ${version}`);
     process.exit(1);


### PR DESCRIPTION
We mistakenly published a version of this package with the version number `5.0.202211170` (note trailing `0`)

All future updates in `5.0` are now consider less than that version, preventing users from updating. This PR adds a workaround to always append a `0` to `5.0` builds