### PR TITLE
Fix `patchJsdoctype` invalid pattern filtering

### DIFF
--- a/build/updateGrammar.js
+++ b/build/updateGrammar.js
@@ -43,7 +43,7 @@ function removeNodeTypes(grammar) {
 
 function patchJsdoctype(grammar) {
     grammar.repository['jsdoctype'].patterns = grammar.repository['jsdoctype'].patterns.filter(pattern => {
-        if (pattern.name && pattern.name.indexOf('illegal') >= -1) {
+        if (pattern.name && pattern.name.indexOf('illegal') > -1) {
             return false;
         }
         return true;

--- a/build/updateGrammar.js
+++ b/build/updateGrammar.js
@@ -43,7 +43,7 @@ function removeNodeTypes(grammar) {
 
 function patchJsdoctype(grammar) {
     grammar.repository['jsdoctype'].patterns = grammar.repository['jsdoctype'].patterns.filter(pattern => {
-        if (pattern.name && pattern.name.indexOf('illegal') > -1) {
+        if (pattern.name && pattern.name.includes('illegal')) {
             return false;
         }
         return true;


### PR DESCRIPTION
Probably a typo. Anyways, `indexOf() >= -1` always returns true, changed the comparison to `> -1` to actually remove invalid patterns